### PR TITLE
setuptools added to requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,4 @@ python-binance==1.0.19
 polygon-api-client
 pyti
 git+https://github.com/twopirllc/pandas-ta.git@development#egg=pandas-ta
+setuptools


### PR DESCRIPTION
When following the guide in docs/docs/dev/build.md, running **python3 populate.py** fails due to a missing dependency on setuptools.